### PR TITLE
chore(actions): remove pnpm version in deploy workflow yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## 概要

deploy workflowのpnpm setupでエラーが吐いているので、バージョンの指定を削除
(package.jsonで指定しているため重複していた)