### PR TITLE
PWAのアイコンが反映されるように

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,5 +9,5 @@ export const middleware = async () => {
 }
 
 export const config = {
-  matcher: ['/((?!login|api|_next|favicon.ico|robots.txt|sitemap.xml|.*.png).*)'],
+  matcher: ['/((?!login|api|_next|favicon.ico|robots.txt|manifest.json|sitemap.xml|.*.png).*)'],
 } satisfies MiddlewareConfig


### PR DESCRIPTION
## issue

resolve #29

## description

以前はmiddlewareにリダイレクトされてしまっていて画像にアクセスできなくなっていたため、画像をmiddlewareから除外するようにした

## screenshots (optional)

