### PR TITLE
ダークテーマを描画前に反映する

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { twJoin } from 'tailwind-merge'
 import { Footer } from '../components/layouts/footer'
 import { Header } from '../components/layouts/header'
 import { SideMenu } from '../components/layouts/side-menu/side-menu'
-import { ThemeProvider } from '../lib/theme-provider'
+import { ThemeLoader, ThemeProvider } from '../lib/theme-provider'
 import '../styles/globals.css'
 import styles from './layout.module.css'
 
@@ -17,8 +17,9 @@ export const metadata: Metadata = {
 }
 
 const RootLayout = ({ children }: { children: ReactNode }) => (
-  <html lang="ja">
+  <html lang="ja" suppressHydrationWarning={true}>
     <body className="scrollbar-thin scrollbar-thumb-background-200 scrollbar-thumb-rounded-full scrollbar-track-transparent overflow-y-scroll">
+      <ThemeLoader />
       <SessionProvider>
         <ThemeProvider>
           <NuqsAdapter>

--- a/src/lib/theme-provider.tsx
+++ b/src/lib/theme-provider.tsx
@@ -24,3 +24,15 @@ export const ThemeProvider: FC<ThemeProviderProps> = ({ children }) => {
     </Provider>
   )
 }
+
+export const ThemeLoader = () => (
+  <script
+    // biome-ignore lint/security/noDangerouslySetInnerHtml:
+    dangerouslySetInnerHTML={{
+      __html: `
+            const theme = localStorage.getItem('anicotto:theme')
+            document.documentElement.classList.add(theme ?? 'light')
+        `,
+    }}
+  />
+)


### PR DESCRIPTION
## issue

resolve #28

## description

themeのクラスを与えるjsをscriptタグで埋め込んだ。
この手法は[tailwindlabs/tailwindcss.com](https://github.com/tailwindlabs/tailwindcss.com/blob/6ea2d48c1768f169d3d0d581dca4c2f4905f3157/src/app/layout.tsx#L114-L164)を参考にした

この変更により、ダークモードでリロードしても画面が一回明るくなることが解消される

## screenshots (optional)

