### PR TITLE
未ログイン時にmanifest.webmanifestをリダイレクトしない

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,5 +9,7 @@ export const middleware = async () => {
 }
 
 export const config = {
-  matcher: ['/((?!login|api|_next|favicon.ico|robots.txt|manifest.json|sitemap.xml|.*.png).*)'],
+  matcher: [
+    '/((?!login|api|_next|favicon.ico|robots.txt|manifest.webmanifest|sitemap.xml|.*.png).*)',
+  ],
 } satisfies MiddlewareConfig


### PR DESCRIPTION
## issue

resolve #

## description

middlewareのmathcerに`manifest.json`と書いていたせいで、未ログイン時にmanifest.jsonがリダイレクトされてしまっていた。
`manifest.webmanifest`に修正して解決

## screenshots (optional)

